### PR TITLE
add: SpongeForgeを追加

### DIFF
--- a/servers/v1/README.md
+++ b/servers/v1/README.md
@@ -115,3 +115,4 @@ Note: pack distribution is not public, however you can play same combination.
 |:---|:---|:---|
 |[Xaero's Minimap](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap)|[22.7.0](https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap/files/3778428)|Custom License [inclusion: allowed]|
 |[Xaero's World Map](https://www.curseforge.com/minecraft/mc-mods/controlling/files)|[1.21.1](https://www.curseforge.com/minecraft/mc-mods/xaeros-world-map/files/3779536)|Custom License [inclusion: allowed]|
+|[SpongeForge](https://spongepowered.org/downloads/spongeforge)|[1.12.2-2838-7.4.7](https://spongepowered.org/downloads/spongeforge)| [MIT License](https://github.com/SpongePowered/SpongeForge/blob/stable-7/LICENSE.txt) |


### PR DESCRIPTION
## 変更された内容

- SpongeForgeをServerOnlymodに追加

## SpongeForgeが必要な理由

- Velocityのプレイヤーデータ転送がforgeの標準だと機能しないため

## note: 導入後編集が必要なconfig
- `config/sponge/global.conf`
　- 23行目の `ip-forwarding` をtrueに
　- 384行目の `bungeecord` をtrueに

- `server.properties`
　- `online-mode` をfalseに