### PR TITLE
feat(config): merge patch 972802082635677776

### DIFF
--- a/servers/v1/data/common/config/mcassistant.cfg
+++ b/servers/v1/data/common/config/mcassistant.cfg
@@ -26,7 +26,7 @@ general {
     B:cutdownEnable=true
 
     # Break any blocks in wide range when given haste potion effect
-    B:flatassistEnable=true
+    B:flatassistEnable=false
 
     # Remove wide range leaves by axe on left click
     B:leaveassistEnable=true
@@ -35,9 +35,9 @@ general {
     B:mineassistEnable=true
 
     # Mounting automatically when you place a vehicles, and returning to inventory it when you dismount.
-    B:mountassistEnable=true
+    B:mountassistEnable=false
 
-    # Sheep shearing can wide range on right click by shear 
+    # Sheep shearing can wide range on right click by shear
     B:shearassistEnable=true
 
     # Place torch by pickaxe and shovel on right click
@@ -121,7 +121,7 @@ general {
         S:requireEnchantLevel=
 
         # Threshold of satiety to enable collective destruction (0-20)
-        I:requireHunger=15
+        I:requireHunger=6
 
         # Potion effect and level enabling collective destruction
         # StatusID:Level
@@ -433,7 +433,7 @@ general {
     ##########################################################################################################
     # shearassist
     #--------------------------------------------------------------------------------------------------------#
-    # Sheep shearing can  wide range on right click by shear 
+    # Sheep shearing can  wide range on right click by shear
     ##########################################################################################################
 
     shearassist {
@@ -627,10 +627,8 @@ itemregister {
         # To regist specific items to ore dictionary, entering one item per line by following format
         # OreDictionaryName:ModID:ItemName
         S:values <
-            
+
          >
     }
 
 }
-
-


### PR DESCRIPTION
・採掘速度上昇の効果が付いているとき(よくわからん挙動で)ブロックをたくさん削る機能を廃止
・トロッコやボートを置いたとき自動で乗ったり、降りたとき自動でインベントリに入る機能を廃止
・原木の一番下を壊すと上から削れる機能を廃止(効率強化で一括破壊は残してある)
・満腹度が肉7個分を下回ると鉱石の一括破壊ができなかった→3個分までおｋにした